### PR TITLE
ENH: enable Travis to run shellcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+# ATM we are pure bash scripts but eventually might RF into Python
+language: python
+
+
+install:
+    - travis_retry sudo apt-get install singularity-container shellcheck bats 
+
+script:
+    - shellcheck scripts/create_singularities

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,11 @@ language: python
 
 
 install:
-    - travis_retry sudo apt-get install singularity-container shellcheck bats 
+  # So we get all backports etc
+  - bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
+  - travis_retry sudo apt-get update -qq
+  - travis_retry sudo apt-get install eatmydata  # to speedup some installations
+  - travis_retry sudo eatmydata apt-get install singularity-container shellcheck bats
 
 script:
     - shellcheck scripts/create_singularities

--- a/scripts/create_singularities
+++ b/scripts/create_singularities
@@ -37,22 +37,22 @@ IMAGES_DIR="images"
 
 
 function debug() {
-	: # echo -e "D: $@" >&2
+	: # echo -e "D:" "$@" >&2
 }
 
 function info() {
-	echo -e "I: $@" >&2
+	echo -e "I:" "$@" >&2
 }
 
 function error() {
-	echo -e "E: $@" >&2
+	echo -e "E:" "$@" >&2
 }
 
 
 
 function get_last_docker_version_tag() {
 	dh="$1"
-	j=$(curl -s -k https://registry.hub.docker.com/v1/repositories/$dh/tags)
+	j=$(curl -s -k "https://registry.hub.docker.com/v1/repositories/$dh/tags")
 	versions=$(echo "$j" | jq -c '.[]["name"]' | sed -e 's,",,g' | sort -Vr)
 	nversions=$(echo "$versions" | wc -l)
 	if [ "$nversions" -gt 1 ]; then
@@ -187,7 +187,7 @@ function add_singularity_versioned_image() {
 
 function generate_singularity_for_docker_image() {
 	githubid="$1"
-	dockerhubid="$(echo "$githubid" | tr 'A-Z' 'a-z')"
+	dockerhubid="$(echo "$githubid" | tr '[:upper:]' '[:lower:]')"
 	family="$2"
 
 	info "$family <- docker $dockerhubid"
@@ -234,7 +234,7 @@ function add_singularity_image_from_collection() {
 curl -s -k https://raw.githubusercontent.com/BIDS-Apps/bids-apps.github.io/master/_config.yml \
 	| awk '/^ *dh:/{print $2}' \
 	| sed -e "s,',,g" \
-	| while read dockerhubid; do
+	| while read -r dockerhubid; do
 	generate_singularity_for_docker_image "$dockerhubid" "bids"
 done
 


### PR DESCRIPTION
#11 could either adopt it (if we merge it in) to run shellcheck on all script/* files (all bash ATM) or we could do that later.