### PR TITLE
Exclude SC2236 (complaining about "! -z") in shellcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ install:
   - git annex upgrade  # we need v7 for the unlocked test img
 
 script:
-    - grep -m 1 -l '^#!/bin/.*sh' -- scripts/* | xargs shellcheck -e SC2236
+    - grep -m 1 -l '^#!/bin/.*sh' -- scripts/* | xargs shellcheck
     - bats -t scripts/tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ install:
   - git annex upgrade  # we need v7 for the unlocked test img
 
 script:
-    - grep -m 1 -l '^#!/bin/.*sh' -- scripts/* | xargs shellcheck
+    - grep -m 1 -l '^#!/bin/.*sh' -- scripts/* | xargs shellcheck -e SC2236
     - bats -t scripts/tests

--- a/scripts/create_singularities
+++ b/scripts/create_singularities
@@ -223,7 +223,7 @@ function generate_singularity_for_docker_image() {
 	info "$family <- docker $dockerhubid"
 	last_version=$(get_last_docker_version_tag "$dockerhubid")
 
-	if [ ! -z "$last_version" ]; then
+	if [ -n "$last_version" ]; then
 		last_version_pure=${last_version%%@*}
 		last_version_tag=${last_version#*@}
 


### PR DESCRIPTION
Shellcheck was complaining about `! -z` at: https://github.com/ReproNim/containers/blob/26099a904502bcd55fbbb4cc8fd5702b34f5dc6e/scripts/create_singularities#L226

I'm excluding this shellcheck test rather than "fixing" the issue because `test -n` and `test -n ""` behave differently, but using `-z` is consistent.