### PR TITLE
ENH: Changed base image for singularity-shim to the 'slim' docker ima…

### DIFF
--- a/scripts/Dockerfile.singularity-shim
+++ b/scripts/Dockerfile.singularity-shim
@@ -1,6 +1,8 @@
-FROM singularityware/singularity:latest
+FROM singularityware/singularity:v3.3.0-slim
 
-RUN printf '#!/bin/bash\n\
+RUN apk update \
+    && apk add bash sudo \
+    && printf '#!/bin/bash\n\
         set -eu\n\
         USERNAME=$(sed -rn "s/^([^:]+):[^:]+:${UID}:.*/\\1/p" /etc/passwd)\n\
         GROUPNAME=$(sed -rn "s/^([^:]+):[^:]+:${GID}:.*/\\1/p" /etc/group)\n\
@@ -10,9 +12,9 @@ RUN printf '#!/bin/bash\n\
                 GROUPNAME=host-user\n\
                 addgroup -g $GID host-user\n\
             fi\n\
-            adduser -u $UID -G "$GROUPNAME" -H -D host-user\n\
+            adduser -u $UID -G "$GROUPNAME" -D host-user\n\
         fi\n\
-        sudo -u "$USERNAME" /usr/local/bin/singularity "$@"\n\
+        sudo -u "$USERNAME" /usr/local/singularity/bin/singularity "$@"\n\
     ' > /entrypoint.sh \
     && chmod +x /entrypoint.sh
 


### PR DESCRIPTION
…ge of singularity

Fixes #26 

@yarikoptic 

The base Docker image for the singularity-shim was changed to the "slim" version.

Also, for image stability, an exact image version is used for the base image rather than the "latest".

The new version of the singularity-shim image is 68MB compressed in the hub and 140MB uncompressed after it is pulled locally.

The new smaller image has been pushed to Docker Hub.
