### PR TITLE
ENH: Added line to singularity-shim Dockerfile to clean up apk cache

### DIFF
--- a/scripts/Dockerfile.singularity-shim
+++ b/scripts/Dockerfile.singularity-shim
@@ -2,6 +2,7 @@ FROM singularityware/singularity:v3.3.0-slim
 
 RUN apk update \
     && apk add bash sudo \
+    && rm -rf /var/cache/apk/* \
     && printf '#!/bin/bash\n\
         set -eu\n\
         USERNAME=$(sed -rn "s/^([^:]+):[^:]+:${UID}:.*/\\1/p" /etc/passwd)\n\


### PR DESCRIPTION
The updated Docker image has been pushed to Docker Hub.

The uncompressed image is down to 139MB