### PR TITLE
OSX travis enhancements

### DIFF
--- a/travis/dummy_docker
+++ b/travis/dummy_docker
@@ -3,6 +3,14 @@
 # Dummy docker command for OSX testing.  We handle the command lines that 
 # the tests use (and give the output the tests expect).
 
+# If the script is running under BATS, FD 3 is open (for output that isn't 
+# caught by BATS and passes right through to the output).  If not, we need 
+# to open it.
+if ! ( echo >&3 ) 2> /dev/null
+then
+    exec 3>&2
+fi
+
 if [ "$*" = "pull mjtravers/singularity-shim:latest" ]
 then
     cat << EOF
@@ -46,7 +54,13 @@ arg #6=<foo&>
 arg #7=<\${foo}>
 EOF
 else
-    echo "$0: unhandled command line" >&2
+    echo "$0: unhandled command line:" >&3
+    i=1
+    for arg in "$@"
+    do
+        echo "    \$${i} = <$arg>" >&3
+        i=$(($i+1))
+    done
     exit 1
 fi
 

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -14,8 +14,8 @@ then
     sudo eatmydata apt-get install singularity-container shellcheck bats git-annex-standalone
 else
     # osx
-    brew install shellcheck
-    brew install git-annex
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install shellcheck
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install git-annex
     git clone https://github.com/sstephenson/bats.git ~/bats
     ( cd ~/bats ; sudo ./install.sh /usr/local )
     sudo cp travis/dummy_docker /usr/local/bin/docker


### PR DESCRIPTION
Minor enhancements:
- Not updating homebrew on travis (which we don't need; this saves a lot of time)
- Displaying the arguments of an unhandled command line in dummy_docker (easier for fixing failing tests)
I'll be pulling these into yarikoptic/bf-sing-c for #27.