### PR TITLE
RF/BF: rely on "hash singularity" command instead of OSTYPE check to decide to use singularity

### DIFF
--- a/scripts/singularity_cmd
+++ b/scripts/singularity_cmd
@@ -97,7 +97,7 @@ else
 fi
 
 # set -x
-if [ "$OSTYPE" == "linux-gnu" ] && [ -z "${REPRONIM_USE_DOCKER:-}" ]; then
+if hash singularity 2>/dev/null && [ -z "${REPRONIM_USE_DOCKER:-}" ]; then
 	singularity "$cmd" -W "$tmpdir" "${SARGS[@]}"
 else
 	DARGS=(


### PR DESCRIPTION
This should allow to use singularity on OSX where there is some build/shimming
installation provided by singularity itself (Should close #33 if works).
Unfortunately for me currently tests fail locally: https://github.com/ReproNim/containers/issues/40 . Let's see if they still pass on travis