### PR TITLE
RF: use quay.io images with custom one for -arm64

### DIFF
--- a/scripts/singularity_cmd
+++ b/scripts/singularity_cmd
@@ -155,6 +155,6 @@ else
 
 	docker run \
 		   "${DARGS[@]}" \
-		   repronim/containers:latest \
+		   quay.io/repronim/containers:latest$(test `uname -m` = arm64 && echo '-arm64' || echo '') \
 		   "$cmd" "${SARGS[@]}"
 fi


### PR DESCRIPTION
Unfortunately ATM -arm64 builds have not succeeded since I need to somehow specify the architecture.

If/when merged Fixes #67 which will collect more notes meanwhile