### PR TITLE
BF: freeze_versions - do not hardcode .sing extension, make overall more flexible, robust and test

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,6 +29,3 @@ jobs:
 
     - name: Test example in the README.md
       run: bash <(sed -n -e '/^ *#!/,/^```$/p' README.md | grep -v '```')
-
-    - name: Verify that images are available either from web or our server
-      run: if git annex find --not --in web --and --not --in datalad-public | grep -q . ; then exit 1; fi 

--- a/scripts/freeze_versions
+++ b/scripts/freeze_versions
@@ -13,6 +13,13 @@
 #
 #     scripts/freeze_versions bids-mriqc=0.15.0 bids-fmriprep=1.4.1 bids-aa
 #
+#     and it can take partial version specification if there is only one
+#     image with that version prefix is available, e.g.
+#
+#     scripts/freeze_versions neurodesk-fmriprep=20.1
+#
+#     would freeze to the 20.1.3 version as that is the only one available for 20.1.
+#
 #  2. Copy container definitions, and this way freeze within super-dataset
 #     where this one was included as code/containers subdataset
 #
@@ -113,13 +120,21 @@ for arg in "$@"; do
 	if [ "$img" != "$arg" ]; then  # we had version specified
 		ver=${arg#*=}
 		echo "I: $img -> $ver"
-		imgpath="images/${img%%-*}/${img}--${ver}.sing"
-		# Check if exists! we cannot freeze to unknown.  There is no easy
-		# check if file exists as a symlink or not
-		if ! /bin/ls -d "$topd/$imgpath" &>/dev/null ; then
-			error "There is no $topd/$imgpath .  Available images for the app are:"
-			/bin/ls -1 "$topd/images/${img%%-*}/${img}--"* | sed -e 's,^,  ,g' 1>&2
-			exit 1
+		imgprefix=$topd/images/${img%%-*}/${img}--${ver}
+		if /bin/ls -d "$imgprefix" &>/dev/null; then
+			# we were specified precisely with extension etc
+			imgpath="$imgprefix"
+		else
+			imgpaths=( $(/bin/ls -1 "$imgprefix".*) )
+			case ${#imgpaths[@]} in
+				0) error "There is no ${imgprefix}.* files.  Available images for the app are:"
+				   /bin/ls -1 "$topd/images/${img%%-*}/${img}--"* | sed -e 's,^,  ,g' 1>&2
+				   exit 1;;
+				1) imgpath=${imgpaths[0]};;
+				*) error "There are multiple images available. Include extension into your version specification. Available images are:"
+				   echo "${imgpaths[@]}" | sed -e 's, ,\n  ,g' -e 's,^,  ,g'
+				   exit 1;;
+			esac
 		fi
 	else
 		# freeze to current

--- a/scripts/tests/test_freeze_versions.bats
+++ b/scripts/tests/test_freeze_versions.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+#
+# This test uses the Bash Automated Testing System
+# See: https://github.com/bats-core/bats-core
+#
+# Install instructions:
+#   git clone https://github.com/bats-core/bats-core.git
+#   cd bats-core
+#   sudo ./install.sh /usr/local
+#
+# Several ways to run the test:
+#   ./test_singularity_cmd.bats
+#   bats test_freeze_versions.bats
+#   bats .
+
+load test_helpers
+
+arg_test_img="$BATS_TEST_DIRNAME/arg-test.simg"
+topdir="$BATS_TEST_DIRNAME/../.."
+freeze_versions="$topdir/scripts/freeze_versions"
+
+@test "fail to freeze nonexisting" {
+	$freeze_versions neurodesk-romeo=0.999.9 && { echo "should have failed"; exit 1; } || :
+}
+
+@test "test freezing with extension" {
+	$freeze_versions neurodesk-romeo=3.2.4.simg && git diff .datalad | grep "romeo--3.2.4.simg  # frozen" && git checkout .datalad
+}
+
+@test "partial specification" {
+	# first I implemented that this would be possible and thought to promote it as a "feature"
+	$freeze_versions neurodesk-slicer=4.11.2020 && { echo "should have failed"; git diff .datalad; git checkout .datalad; exit 1; } || :
+	# we will have it available only when version to the . is specified, e.g. if someone wants to freeze to
+	# specific major.minor so we will just automatically choose the one with some .PATCH if there is only 1
+	$freeze_versions neurodesk-fmriprep=20.1 && git diff .datalad | grep "fmriprep--20.1.3.simg  # frozen" && git checkout .datalad
+
+}

--- a/scripts/tests/test_repo_state.bats
+++ b/scripts/tests/test_repo_state.bats
@@ -1,0 +1,14 @@
+#!/usr/bin/env bats
+#
+# This test uses the Bash Automated Testing System
+# See: https://github.com/bats-core/bats-core
+#
+
+load test_helpers
+
+@test "verify that images are available either from web or our server" {
+    unavail=$(git annex find --not --in web --and --not --in 71c620b5-997f-4849-bb30-c42dbb48a51e)
+	if [ -n "$unavail" ]; then
+		fail "Following files are not available from the web or our datasets.datalad.org remote: $unavail"
+	fi
+}


### PR DESCRIPTION
see added tests for use cases -- can specify incomplete version or an entire filename with extension now.

ref: https://github.com/ReproNim/containers/issues/64#issuecomment-1498510384 

@stebo85 - if you have a pick/provide feedback - would be appreciated.