### PR TITLE
add --no-datalad-get to MRIQC runs by default

### DIFF
--- a/.datalad/config
+++ b/.datalad/config
@@ -47,7 +47,7 @@
 	cmdexec = {img_dspath}/scripts/singularity_cmd run {img} {cmd}
 	image = images/bids/bids-mindboggle--0.0.4-1.sing
 [datalad "containers.bids-mriqc"]
-	cmdexec = {img_dspath}/scripts/singularity_cmd run {img} {cmd}
+	cmdexec = {img_dspath}/scripts/singularity_cmd run {img} {cmd} --no-datalad-get
 	image = images/bids/bids-mriqc--24.0.2.sing
 [datalad "containers.bids-mrtrix3-connectome"]
 	cmdexec = {img_dspath}/scripts/singularity_cmd run {img} {cmd}


### PR DESCRIPTION
partially solves #131 for 24.x series