### PR TITLE
fix shellcheck

### DIFF
--- a/scripts/check_images--help
+++ b/scripts/check_images--help
@@ -3,6 +3,6 @@
 #
 # Inspired by  https://github.com/ReproNim/containers/issues/137#issuecomment-2877505303
 #
-git annex find --in here | grep '\.si*' | while read f; do
+git annex find --in here | grep '\.si*' | while read -r f; do
     { singularity run "$f" --help 2>&1 && echo "$f: ok" || echo "$f: failed to execute --help" >&2; } | grep -q "no runscript" && echo "$f: no runscript" >&2; 
 done


### PR DESCRIPTION
currently blocking the tests from running

fixes this shellcheck error:

```
In ./scripts/check_images--help line 6:
git annex find --in here | grep '\.si*' | while read f; do
                                                ^--^ SC2162 (info): read without -r will mangle backslashes.
```