### PR TITLE
test: replace ubuntu-20.04 with ubuntu-latest and install/use datalad etc from pypi not neurodebian

### DIFF
--- a/.github/workflows/base-tests.yaml
+++ b/.github/workflows/base-tests.yaml
@@ -21,10 +21,10 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           # So we get all backports etc
-          bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
+          # bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
           sudo apt-get update -qq
           sudo apt-get install eatmydata  # to speedup some installations
-          sudo eatmydata apt-get install singularity-container shellcheck bats git-annex-standalone
+          sudo eatmydata apt-get install singularity-container shellcheck bats git-annex
 
       - name: Install dependencies (macOS)
         if: startsWith(matrix.os, 'macos')

--- a/.github/workflows/base-tests.yaml
+++ b/.github/workflows/base-tests.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - ubuntu-20.04
+          - ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,7 +19,8 @@ jobs:
         sudo apt-get update -qq
         sudo apt-get install eatmydata
         sudo eatmydata apt-get install singularity-container gnupg moreutils strace
-        sudo eatmydata apt-get install datalad datalad-container
+        sudo eatmydata apt-get install datalad
+        pip install datalad-container
         git config --global user.email "test@example.com"
         git config --global user.name "CI Almighty"
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,9 +18,8 @@ jobs:
         # bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
         sudo apt-get update -qq
         sudo apt-get install eatmydata
-        sudo eatmydata apt-get install singularity-container gnupg moreutils strace
-        sudo eatmydata apt-get install datalad
-        pip install datalad-container
+        sudo eatmydata apt-get install singularity-container gnupg moreutils strace git-annex
+        pip install datalad datalad-container
         git config --global user.email "test@example.com"
         git config --global user.name "CI Almighty"
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up system
       shell: bash
       run: |
-        bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
+        # bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
         sudo apt-get update -qq
         sudo apt-get install eatmydata
         sudo eatmydata apt-get install singularity-container gnupg moreutils strace


### PR DESCRIPTION
Need because the tests are auto-cancelled with the following message:

```
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
```