### PR TITLE
Fix typing CI: bump runner Python 3.8→3.13, pin mypy target to 3.10

### DIFF
--- a/.github/workflows/typing.yaml
+++ b/.github/workflows/typing.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.8'
+          python-version: '3.13'
 
       - name: Install Python dependencies
         run: |

--- a/scripts/mypy.ini
+++ b/scripts/mypy.ini
@@ -1,4 +1,8 @@
 [mypy]
+# Check against the minimum Python supported by the scripts
+# (requires-python = ">=3.10" in create_singularities), regardless
+# of the interpreter mypy itself runs under.
+python_version = 3.10
 allow_incomplete_defs = False
 allow_untyped_defs = False
 ignore_missing_imports = True


### PR DESCRIPTION
## CI ground truth (verified 2026-08-06)

Run history for the last week is almost entirely green — all three badges are legitimately passing, the nightly scheduled runs of `tests.yaml` ("Additional tests", cron `30 01 * * *`) have succeeded every night, and base tests are clean. **One exception**: the typing workflow **failed on master this morning** ([run 31064747858](https://github.com/ReproNim/containers/actions/runs/31064747858), 2026-08-06 02:08 UTC), and the cause is exactly the Python 3.8 pin — nox crashed on import before mypy even ran:

```
File ".../python3.8/site-packages/argcomplete/completers.py", line 30, in BaseCompleter
    ) -> Iterable[str]:
TypeError: 'ABCMeta' object is not subscriptable
```

nox's `argcomplete` dependency now uses PEP 585 generics at class-definition time, which is a syntax-level crash on 3.8 (EOL since Oct 2024). A later run the same day passed again (different dependency resolution), so the badge is green — but the pin is actively flaky-breaking runs, not just cosmetically stale.

## The underlying inconsistency

`typing.yaml` pinned `python-version: '3.8'`, but the only file the job checks, `scripts/create_singularities`, declares `requires-python = ">=3.10"` in its PEP 723 header and uses 3.10+ annotation syntax (`list[str]`, `int | None`, …). Since `scripts/mypy.ini` set no `python_version`, mypy targeted whatever interpreter ran it — so the job validated the script against a Python it refuses to run on, passing only because `from __future__ import annotations` keeps the annotations lazy.

## Fix

- **`.github/workflows/typing.yaml`**: `python-version: '3.8'` → `'3.13'`. The interpreter now only hosts the tooling (nox/mypy), so newest stable is appropriate — and it fixes the actual argcomplete crash.
- **`scripts/mypy.ini`**: add `python_version = 3.10` so mypy's check target matches the script's declared floor, independent of the runner image.

### Why not `uv run` (single-sourcing the version in the PEP 723 header)?

It was considered, but mypy does not read `requires-python` from script metadata — even under `uv run`, mypy's target would silently follow whatever interpreter uv happens to pick (any ≥3.10). The explicit `python_version` pin in `mypy.ini` is the only way to make the check target the script's floor, and once that pin exists, the workflow's interpreter choice no longer affects what is checked.

## Verification

```
$ cd scripts && nox -e typing
nox > mypy create_singularities
Success: no issues found in 1 source file
nox > Session typing was successful.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwCAVTauHF8cgUnBqv31py

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwCAVTauHF8cgUnBqv31py)_