### PR TITLE
Add timestamps to logging output

### DIFF
--- a/scripts/create_singularities
+++ b/scripts/create_singularities
@@ -573,7 +573,11 @@ def main(push: bool, image_groups: tuple[str, ...], no_singularity_check: bool, 
 
         sys.excepthook = _pdb_excepthook
 
-    logging.basicConfig(format="[%(levelname)-8s] %(message)s", level=logging.INFO)
+    logging.basicConfig(
+        format="%(asctime)s [%(levelname)-8s] %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S%z",
+        level=logging.INFO,
+    )
 
     # Use local dedicated "tmp/" directory since any other might be too small
     topdir = Path(__file__).parent.parent

--- a/scripts/create_singularities
+++ b/scripts/create_singularities
@@ -60,7 +60,6 @@ import logging
 import os
 from pathlib import Path
 import re
-import shutil
 import subprocess
 import sys
 from time import sleep
@@ -68,7 +67,6 @@ from typing import Any, Optional, cast
 import requests
 
 import datalad.api as dl
-from datalad.support.exceptions import IncompleteResultsError
 
 log = logging.getLogger(__name__)
 
@@ -289,47 +287,12 @@ class Builder:
                 to_download = True
 
             if to_download:
-                # Retry on transient download failures (e.g. connection reset /
-                # IncompleteRead) with exponential backoff. These have also been
-                # observed to coincide with the target filesystem running low on
-                # space, so log free space alongside each failure to make that
-                # diagnosable from the logs after the fact.
-                max_attempts = 3
-                sleepiter = exp_wait(attempts=max_attempts)
-                attempt = 0
-                while True:
-                    attempt += 1
-                    try:
-                        out = dl.download_url(
-                            img.urls[0],
-                            path=imagefile,
-                            save=False,
-                            overwrite=True,
-                        )
-                        break  # Success, exit retry loop
-                    except IncompleteResultsError as e:
-                        free = shutil.disk_usage(outdir).free
-                        # Remove any partial download so the retry (or a human
-                        # investigating disk usage) isn't misled by it.
-                        if imagefile.exists():
-                            imagefile.unlink()
-                        if (wait := next(sleepiter, None)) is not None:
-                            log.warning(
-                                "Download of %s failed on attempt %d/%d "
-                                "(%.1f GiB free on %s): %s; "
-                                "sleeping for %f seconds and retrying",
-                                img.container, attempt, max_attempts,
-                                free / 2**30, outdir, e, wait,
-                            )
-                            sleep(wait)
-                        else:
-                            # Out of retries
-                            log.error(
-                                "Download of %s failed after %d attempts "
-                                "(%.1f GiB free on %s): %s",
-                                img.container, attempt, free / 2**30, outdir, e,
-                            )
-                            raise
+                out = dl.download_url(
+                    img.urls[0],
+                    path=imagefile,
+                    save=False,
+                    overwrite=True,
+                )
                 key = ds.repo.add(str(imagefile))['key']
                 commit_msg = f"neurodesk: register URL(s) for {img.container}"
                 for url in img.urls:

--- a/scripts/create_singularities
+++ b/scripts/create_singularities
@@ -60,6 +60,7 @@ import logging
 import os
 from pathlib import Path
 import re
+import shutil
 import subprocess
 import sys
 from time import sleep
@@ -67,6 +68,7 @@ from typing import Any, Optional, cast
 import requests
 
 import datalad.api as dl
+from datalad.support.exceptions import IncompleteResultsError
 
 log = logging.getLogger(__name__)
 
@@ -287,12 +289,47 @@ class Builder:
                 to_download = True
 
             if to_download:
-                out = dl.download_url(
-                    img.urls[0],
-                    path=imagefile,
-                    save=False,
-                    overwrite=True,
-                )
+                # Retry on transient download failures (e.g. connection reset /
+                # IncompleteRead) with exponential backoff. These have also been
+                # observed to coincide with the target filesystem running low on
+                # space, so log free space alongside each failure to make that
+                # diagnosable from the logs after the fact.
+                max_attempts = 3
+                sleepiter = exp_wait(attempts=max_attempts)
+                attempt = 0
+                while True:
+                    attempt += 1
+                    try:
+                        out = dl.download_url(
+                            img.urls[0],
+                            path=imagefile,
+                            save=False,
+                            overwrite=True,
+                        )
+                        break  # Success, exit retry loop
+                    except IncompleteResultsError as e:
+                        free = shutil.disk_usage(outdir).free
+                        # Remove any partial download so the retry (or a human
+                        # investigating disk usage) isn't misled by it.
+                        if imagefile.exists():
+                            imagefile.unlink()
+                        if (wait := next(sleepiter, None)) is not None:
+                            log.warning(
+                                "Download of %s failed on attempt %d/%d "
+                                "(%.1f GiB free on %s): %s; "
+                                "sleeping for %f seconds and retrying",
+                                img.container, attempt, max_attempts,
+                                free / 2**30, outdir, e, wait,
+                            )
+                            sleep(wait)
+                        else:
+                            # Out of retries
+                            log.error(
+                                "Download of %s failed after %d attempts "
+                                "(%.1f GiB free on %s): %s",
+                                img.container, attempt, free / 2**30, outdir, e,
+                            )
+                            raise
                 key = ds.repo.add(str(imagefile))['key']
                 commit_msg = f"neurodesk: register URL(s) for {img.container}"
                 for url in img.urls:


### PR DESCRIPTION
## Summary
Enhanced logging output by adding timestamps to all log messages in the `create_singularities` script.

## Changes
- Updated `logging.basicConfig()` to include `%(asctime)s` in the log format string
- Added `datefmt` parameter with ISO 8601 format (`%Y-%m-%dT%H:%M:%S%z`) for consistent, machine-readable timestamps
- Reformatted the configuration call for improved readability

## Details
Log messages will now display in the format: `2024-01-15T10:30:45+0000 [INFO    ] message text` instead of just `[INFO    ] message text`. This makes it easier to track when events occurred during script execution, which is particularly useful for debugging and monitoring long-running processes.

https://claude.ai/code/session_01KRKz2v6yZT7BqFeVRAtHgC